### PR TITLE
Allow for multiple config files; change config loading order

### DIFF
--- a/zed_wrapper/launch/zed_camera.launch.py
+++ b/zed_wrapper/launch/zed_camera.launch.py
@@ -83,7 +83,7 @@ def launch_setup(context, *args, **kwargs):
 
     config_common_path = LaunchConfiguration('config_path')
     # MODIFIED: allow for multiple user-supplied config files
-    config_common_path = parse_array_param(config_common_path)
+    config_common_path = parse_array_param(config_common_path.perform(context))
     config_ffmpeg = LaunchConfiguration('ffmpeg_config_path')
 
     serial_number = LaunchConfiguration('serial_number')

--- a/zed_wrapper/launch/zed_camera.launch.py
+++ b/zed_wrapper/launch/zed_camera.launch.py
@@ -82,6 +82,8 @@ def launch_setup(context, *args, **kwargs):
     node_name = LaunchConfiguration('node_name')
 
     config_common_path = LaunchConfiguration('config_path')
+    # MODIFIED: allow for multiple user-supplied config files
+    config_common_path = parse_array_param(config_common_path)
     config_ffmpeg = LaunchConfiguration('ffmpeg_config_path')
 
     serial_number = LaunchConfiguration('serial_number')
@@ -163,9 +165,11 @@ def launch_setup(context, *args, **kwargs):
 
     node_parameters = [
             # YAML files
-            config_common_path,  # Common parameters
             config_camera_path,  # Camera related parameters
             config_ffmpeg, # FFMPEG parameters
+
+            # MODIFIED: allow for multiple user-supplied config files
+            *config_common_path,  # Common parameters
             # Overriding
             {
                 'use_sim_time': use_sim_time,


### PR DESCRIPTION
Adding the ability to stack multiple config files together. The use case is for @shruthiR-fauna to be able to load her human-following config as a delta on top of our other configs.

This also changes the load order so that it loads user-supplied configs after Zed-supplied ones, but before CLI-provided parameter overrides.